### PR TITLE
Remove unnecessary CPU ByteBuffer allocation

### DIFF
--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/GlUtils.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/GlUtils.kt
@@ -119,10 +119,9 @@ object GlUtils {
     fun allocateTexture(width: Int, height: Int): Int {
         val texId = generateTexture()
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texId)
-        val byteBuffer = ByteBuffer.allocateDirect(width * height * 4)
         GLES20.glTexImage2D(
             GLES20.GL_TEXTURE_2D, 0, GLES20.GL_RGBA, width, height, 0,
-            GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, byteBuffer
+            GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, null
         )
         checkGlError()
         return texId


### PR DESCRIPTION
Closes #7 

Previously a memory allocation was done for glTexImage2D. This can
be done on the GPU automatically by passing in NULL.

No obvious performance improvement was noticed by removing this
allocation but this should allow the allocation to happen within
the GPU optimally.

Alternatively, a ring-buffer could be created to manage a CPU
allocations but this will be more complex and likely slower than
allowing the GPU to handle this.