### PR TITLE
Separate and improve stats counter

### DIFF
--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/MainActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/MainActivity.kt
@@ -139,7 +139,7 @@ class MainActivity : AppCompatActivity() {
         videoSurfaceManagers.clear()
 
         for (n in 0..NUMBER_OF_STREAMS) {
-            videoSurfaceManagers.add(VideoSurfaceManager(viewModel, glManager, previewSurfaceViews[n]))
+            videoSurfaceManagers.add(VideoSurfaceManager(viewModel, glManager, previewSurfaceViews[n], n+1))
         }
     }
 

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/FpsStats.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/FpsStats.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.hadrosaur.videodecodeencodedemo.VideoHelpers
+
+import dev.hadrosaur.videodecodeencodedemo.MainActivity
+import dev.hadrosaur.videodecodeencodedemo.MainViewModel
+import dev.hadrosaur.videodecodeencodedemo.Utils.getMax
+import dev.hadrosaur.videodecodeencodedemo.Utils.getMin
+
+/**
+ * Keep track of FPS stats
+ *
+ * Uses the ViewModel to log periodically
+ */
+class FpsStats(val viewModel: MainViewModel, val streamNumber: Int) {
+    // Stats counters
+    private var fpsDecodeCounter = 0
+    private var fpsTotalDecodeCounter = 0
+    private var fpsLastMeasuredTime = 0L
+    private var fpsLastLoggedTime = 0L
+
+    // Set up an int array for fps stats to get an idea of choppiness. Ex. 0-55fps+, 12 buckets
+    // 0-4, 5-9, 10-14, 15-19, 20-24 . . . 50-54, 55+
+    private val MAX_FPS_STATS = 60 // max fps we care about for stats
+    private val NUM_FPS_BUCKETS = 6
+    private val FPS_BUCKET_SIZE = MAX_FPS_STATS / NUM_FPS_BUCKETS // 10fps
+    private val LAST_FPS_BUCKET_START = MAX_FPS_STATS - FPS_BUCKET_SIZE // 50+
+    private val fpsBuckets = IntArray(NUM_FPS_BUCKETS) { 0 }
+
+    // Keep track of mix/max fps
+    private var minFps = MAX_FPS_STATS
+    private var maxFps = 0
+
+    // Choppiness = num frames < 30fps
+    private val CHOPPINESS_CUTOFF = 30
+    private val TOO_MANY_CHOPPY_FRAMES = 10
+    private var numChoppyFrames = 0
+
+    private fun resetStatsCounters() {
+        minFps = MAX_FPS_STATS
+        maxFps = 0
+        numChoppyFrames = 0
+        for (i in 0 until NUM_FPS_BUCKETS) {
+            fpsBuckets[i] = 0
+        }
+    }
+
+    fun updateStats() {
+        val currentTime = System.currentTimeMillis()
+        // If this is the first frame, don't calculate stats
+        if (fpsLastLoggedTime == 0L || fpsLastMeasuredTime == 0L) {
+            fpsLastLoggedTime = currentTime
+            fpsLastMeasuredTime = currentTime
+        } else {
+            fpsDecodeCounter++
+            fpsTotalDecodeCounter++
+
+            // viewModel.updateLog("I have decoded ${decodeCounter} video frames.")
+            if (fpsLastMeasuredTime == currentTime) {
+                fpsLastMeasuredTime -= 3 // 0ms since last frame, subtract time to avoid divide by 0
+            }
+            val currentFrameFps = 1000 / (currentTime - fpsLastMeasuredTime)
+
+
+            // Calculate stats for this frame
+            minFps = getMin(minFps, currentFrameFps.toInt())
+            maxFps = getMax(maxFps, currentFrameFps.toInt())
+
+            if (currentFrameFps < CHOPPINESS_CUTOFF) {
+                numChoppyFrames++
+            }
+
+            // Place this frame's fps in the bucket
+            val currentfpsBucketIndex = getMin(currentFrameFps.toInt(), MAX_FPS_STATS - 1) / FPS_BUCKET_SIZE
+            fpsBuckets[currentfpsBucketIndex]++
+
+
+            // If this is a logging frame, output states and reset counters
+            if (fpsDecodeCounter % MainActivity.LOG_VIDEO_EVERY_N_FRAMES == 0) {
+                val averageFps = fpsDecodeCounter / ((currentTime - fpsLastLoggedTime) / 1000.0)
+
+                val averageFpsString = String.format("%.2f", averageFps)
+                val choppyString = if (numChoppyFrames >= TOO_MANY_CHOPPY_FRAMES) " ---CHOPPY---" else ""
+
+                // FPS buckets line
+                var bucketsString1 = ""
+                for (i in 0 until NUM_FPS_BUCKETS) {
+                    if (i == NUM_FPS_BUCKETS -1) {
+                        // Last bucket
+                        bucketsString1 += "[${i * FPS_BUCKET_SIZE}+: ${fpsBuckets[i]}]"
+                    } else {
+                        bucketsString1 += "[${i * FPS_BUCKET_SIZE}-${(i+1) * FPS_BUCKET_SIZE - 1}: ${fpsBuckets[i]}]    "
+                    }
+                }
+                if (streamNumber == 0)
+                    viewModel.updateLog("\n")
+
+                val logString = "V${streamNumber + 1}@frame $fpsTotalDecodeCounter. FPS: min: ${minFps} max: ${maxFps} avg: ${averageFpsString}. Choppy frames: ${numChoppyFrames}${choppyString}.\n\t" +
+                        bucketsString1
+                viewModel.updateLog(logString)
+
+                fpsLastLoggedTime = currentTime // Update for next fps measurement
+                fpsDecodeCounter = 0
+                resetStatsCounters()
+            }
+        }
+
+        fpsLastMeasuredTime = currentTime // Update for next fps measurement
+    }
+}

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/InternalSurfaceTextureRenderer.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/InternalSurfaceTextureRenderer.kt
@@ -29,11 +29,12 @@ import dev.hadrosaur.videodecodeencodedemo.Utils.GlManager
  *
  * Logs to the main log as the render progresses.
  */
-class InternalSurfaceTextureRenderer(val viewModel: MainViewModel, glManager: GlManager, displaySurface: SurfaceView, handler: Handler) : InternalSurfaceTexture.TextureImageListener {
+class InternalSurfaceTextureRenderer(val viewModel: MainViewModel, glManager: GlManager, displaySurface: SurfaceView, handler: Handler, val streamNumber: Int) : InternalSurfaceTexture.TextureImageListener {
     val frameLedger = VideoFrameLedger()
     private val internalSurfaceTexture: InternalSurfaceTexture = InternalSurfaceTexture(viewModel, glManager, displaySurface, handler, this)
     private var onFrameAvailableCounter = 0
     private var doEncode = false
+    private val stats = FpsStats(viewModel, streamNumber)
 
     // The internal Surface from the SurfaceTexture to be decoded to, used by ExoPlayer
     var decoderSurface: Surface? = null
@@ -69,11 +70,14 @@ class InternalSurfaceTextureRenderer(val viewModel: MainViewModel, glManager: Gl
         // that was set in the FrameLedger's onVideoFrameAboutToBeRendered callback
         frameLedger.releaseRenderLock()
 
+
         if (surfaceTimestamp != 0L) {
             // Check if this frame was decoded and sent to the rendered
             if (frameLedger.decodeLedger.containsKey(surfaceTimestamp)) {
                 // Frame matched, increment the frames rendered counter
                 val framesRendered = frameLedger.framesRendered.incrementAndGet()
+
+                stats.updateStats()
 
                 // If this frame matches the requested draw frequency, or the frequency is set to
                 // draw every frame, draw the frame to the preview surface

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoFrameLedger.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoFrameLedger.kt
@@ -39,8 +39,8 @@ import java.util.concurrent.atomic.AtomicInteger
  * time for use in encoding.
  */
 class VideoFrameLedger : VideoFrameMetadataListener {
-    val decodeLedger = ConcurrentHashMap<Long, Long>()
-    val encodeLedger = ConcurrentHashMap<Int, Long>()
+    val decodeLedger = ConcurrentHashMap<Long, Long>() // < ReleaseTimeUs, presentationTimeUs >
+    val encodeLedger = ConcurrentHashMap<Int, Long>() // < frameCount, presentationTimeUs >
     private var framesEntered = AtomicInteger(0)
     var framesRendered = AtomicInteger(0)
     private var encodingCounter = AtomicInteger(0)

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoMediaCodecVideoRenderer.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoMediaCodecVideoRenderer.kt
@@ -49,30 +49,8 @@ class VideoMediaCodecVideoRenderer(
         -1
     )  {
 
-    // Stats counters
-    private var fpsDecodeCounter = 0
-    private var fpsTotalDecodeCounter = 0
-    private var fpsLastMeasuredTime = 0L
-    private var fpsLastLoggedTime = 0L
     private var droppedFrames = 0
     private var lastPresentTime = 0L
-
-    // Set up an int array for fps stats to get an idea of choppiness. Ex. 0-55fps+, 12 buckets
-    // 0-4, 5-9, 10-14, 15-19, 20-24 . . . 50-54, 55+
-    private val MAX_FPS_STATS = 60 // max fps we care about for stats
-    private val NUM_FPS_BUCKETS = 6
-    private val FPS_BUCKET_SIZE = MAX_FPS_STATS / NUM_FPS_BUCKETS // 10fps
-    private val LAST_FPS_BUCKET_START = MAX_FPS_STATS - FPS_BUCKET_SIZE // 50+
-    private val fpsBuckets = IntArray(NUM_FPS_BUCKETS) { 0 }
-
-    // Keep track of mix/max fps
-    private var minFps = MAX_FPS_STATS
-    private var maxFps = 0
-
-    // Choppiness = num frames < 30fps
-    private val CHOPPINESS_CUTOFF = 30
-    private val TOO_MANY_CHOPPY_FRAMES = 10
-    private var numChoppyFrames = 0
 
     /**
      * Keep track of dropped frames
@@ -178,86 +156,19 @@ class VideoMediaCodecVideoRenderer(
         return processSuccess
     }
 
-    private fun resetStatsCounters() {
-        minFps = MAX_FPS_STATS
-        maxFps = 0
-        numChoppyFrames = 0
-        for (i in 0 until NUM_FPS_BUCKETS) {
-            fpsBuckets[i] = 0
-        }
-    }
 
     /**
-     * Adds some logging after each buffer processed to keep track of decode
+     * Update media clock after each buffer processed
      */
     override fun onProcessedOutputBuffer(presentationTimeUs: Long) {
-        val currentTime = System.currentTimeMillis()
-        // If this is the first frame, don't calculate stats
-        if (fpsLastLoggedTime == 0L || fpsLastMeasuredTime == 0L) {
-            fpsLastLoggedTime = currentTime
-            fpsLastMeasuredTime = currentTime
-        } else {
-            fpsDecodeCounter++
-            fpsTotalDecodeCounter++
-
-            // viewModel.updateLog("I have decoded ${decodeCounter} video frames.")
-            if (fpsLastMeasuredTime == currentTime) {
-                fpsLastMeasuredTime -= 3 // 0ms since last frame, subtract time to avoid divide by 0
-            }
-            val currentFrameFps = 1000 / (currentTime - fpsLastMeasuredTime)
-
-
-            // Calculate stats for this frame
-            minFps = getMin(minFps, currentFrameFps.toInt())
-            maxFps = getMax(maxFps, currentFrameFps.toInt())
-
-            if (currentFrameFps < CHOPPINESS_CUTOFF) {
-                numChoppyFrames++
-            }
-
-            // Place this frame's fps in the bucket
-            val currentfpsBucketIndex = getMin(currentFrameFps.toInt(), MAX_FPS_STATS - 1) / FPS_BUCKET_SIZE
-            fpsBuckets[currentfpsBucketIndex]++
-
-
-            // If this is a logging frame, output states and reset counters
-            if (fpsDecodeCounter % LOG_VIDEO_EVERY_N_FRAMES == 0) {
-                val averageFps = fpsDecodeCounter / ((currentTime - fpsLastLoggedTime) / 1000.0)
-
-                val averageFpsString = String.format("%.2f", averageFps)
-                val choppyString = if (numChoppyFrames >= TOO_MANY_CHOPPY_FRAMES) " ---CHOPPY---" else ""
-
-                // FPS buckets line
-                var bucketsString1 = ""
-                for (i in 0 until NUM_FPS_BUCKETS) {
-                    if (i == NUM_FPS_BUCKETS -1) {
-                        // Last bucket
-                        bucketsString1 += "[${i * FPS_BUCKET_SIZE}+: ${fpsBuckets[i]}]"
-                    } else {
-                        bucketsString1 += "[${i * FPS_BUCKET_SIZE}-${(i+1) * FPS_BUCKET_SIZE - 1}: ${fpsBuckets[i]}]    "
-                    }
-                }
-                if (streamNumber == 0)
-                    viewModel.updateLog("\n")
-
-                val logString = "V${streamNumber + 1}@frame $fpsTotalDecodeCounter. FPS: min: ${minFps} max: ${maxFps} avg: ${averageFpsString}. Choppy frames: ${numChoppyFrames}${choppyString}.\n\t" +
-                        bucketsString1
-                viewModel.updateLog(logString)
-
-                fpsLastLoggedTime = currentTime // Update for next fps measurement
-                fpsDecodeCounter = 0
-                resetStatsCounters()
-            }
-        }
-
+        // Check if decoder is stuck
+        // TODO: is this needed for anything?
         if (lastPresentTime == presentationTimeUs && lastPresentTime != 0L) {
             viewModel.updateLog("Last present time is current present time. Frame is stuck! Time: ${presentationTimeUs}")
         }
-
         lastPresentTime = presentationTimeUs
-        mediaClock.updateLastProcessedFrame(presentationTimeUs) // Update media clock with last frame
 
-        fpsLastMeasuredTime = currentTime // Update for next fps measurement
+        mediaClock.updateLastProcessedFrame(presentationTimeUs)
         super.onProcessedOutputBuffer(presentationTimeUs)
     }
 

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoSurfaceManager.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/VideoHelpers/VideoSurfaceManager.kt
@@ -27,10 +27,10 @@ import dev.hadrosaur.videodecodeencodedemo.Utils.GlManager
  * Holder for the internal decoding SurfaceTexture. Ties together the ExoPlayer VideoComponent,
  * and the custom SurfaceTexture and Renderer
  */
-class VideoSurfaceManager(val viewModel: MainViewModel, glManager: GlManager, displaySurface: SurfaceView) {
+class VideoSurfaceManager(val viewModel: MainViewModel, glManager: GlManager, displaySurface: SurfaceView, val streamNumber: Int) {
     private val handler: Handler = Handler()
     var renderer: InternalSurfaceTextureRenderer =
-        InternalSurfaceTextureRenderer(viewModel, glManager, displaySurface, handler)
+        InternalSurfaceTextureRenderer(viewModel, glManager, displaySurface, handler, streamNumber)
 
     private lateinit var player: ExoPlayer
 


### PR DESCRIPTION
Move FPS stats counter out of the video renderer to a separate class.

Count frames when surface is released after rendering, rather than after
ExoPlayer has processed the buffer. This should be slightly more
accurate.