### PR TITLE
Reduce circular buffer de/allocations

### DIFF
--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioBuffer.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioBuffer.kt
@@ -16,6 +16,8 @@
 
 package dev.hadrosaur.videodecodeencodedemo.AudioHelpers
 
+import android.provider.MediaStore.Audio
+import dev.hadrosaur.videodecodeencodedemo.MainActivity.Companion.logd
 import dev.hadrosaur.videodecodeencodedemo.Utils.Copyable
 import java.nio.ByteBuffer
 import java.util.*
@@ -63,5 +65,18 @@ class AudioBuffer (
         buffer.clear()
         Arrays.fill(buffer.array(), 0.toByte())
         buffer.clear()
+    }
+
+    /**
+     * Copy values from this audio buffer into destination buffer
+     */
+    override fun copyInto(destination: Copyable) {
+        val destBuffer = destination as AudioBuffer
+        destBuffer.id = this.id
+        destBuffer.presentationTimeUs = this.presentationTimeUs
+        destBuffer.lengthUs = this.lengthUs
+        destBuffer.size = this.size
+        destBuffer.isLastBuffer = this.isLastBuffer
+        copyIntoByteBuffer(this.buffer, destBuffer.buffer)
     }
 }

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMainTrack.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMainTrack.kt
@@ -248,6 +248,9 @@ class AudioMainTrack {
                         playheadUs = chunk.presentationTimeUs + timePlayedUs
                     }
                     updateMixTrackMediaClocks(playheadUs)
+
+                    // Clear buffer for reuse
+                    buffer.clear()
                 }
             }
 

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/CopyAndPlayAudioSink.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/CopyAndPlayAudioSink.kt
@@ -125,21 +125,16 @@ class CopyAndPlayAudioSink(
             )
         }
 
-        // TODO: add some sort of underrun detection
-
-        // If the play audio toggle is enabled, copy this buffer to the mix track for playback
-        // buffer will be freed after this call so a copy is needed
-//        if (viewModel.getPlayAudioVal()) {
-            audioMixTrack.addAudioChunk(
-                AudioBuffer(
-                    cloneByteBuffer(buffer),
-                    numBuffersHandled + 1,
-                    presentationTimeUs,
-                    bufferLengthUs,
-                    buffer.remaining()
-                )
+        // Add audio chunk to the mix-track
+        audioMixTrack.addAudioChunk(
+            AudioBuffer(
+                buffer,
+                numBuffersHandled + 1,
+                presentationTimeUs,
+                bufferLengthUs,
+                buffer.remaining()
             )
-//        }
+        )
 
         // Update last position
         lastPosition = presentationTimeUs + bufferLengthUs
@@ -153,7 +148,6 @@ class CopyAndPlayAudioSink(
     }
 
     override fun getCurrentPositionUs(sourceEnded: Boolean): Long {
-        // viewModel.updateLog("AudioSink: getCurrentPositionUs is called @ ${lastPosition}")
         return lastPosition
     }
 

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/AudioUtils.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/AudioUtils.kt
@@ -90,6 +90,14 @@ fun cloneByteBuffer(original: ByteBuffer): ByteBuffer {
     return clone
 }
 
+fun copyIntoByteBuffer(source: ByteBuffer, destination: ByteBuffer) {
+    val readOnlyCopy = source.asReadOnlyBuffer()
+    destination.clear()
+    destination.order(source.order())
+    destination.put(readOnlyCopy)
+    destination.flip()
+}
+
 /**
  * Mixes an array of AudioBuffers into the given mainAudio, applying gain.
  *

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/CircularBuffer.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/CircularBuffer.kt
@@ -44,13 +44,11 @@ class CircularBuffer<T>(val size: Int, emptyObject: Copyable, val fullBehaviour:
      *
      * This is necessary because Kotlin doesn't allow for a fixed size array of generics
      */
-    fun set(index: Int, item: T) {
-        if (index < array.size) {
-            // Array is big enough, just set
-            array[index] = item as Copyable
+    fun set(index: Int, item: T, copyInPlace: Boolean) {
+        if (copyInPlace) {
+            (item as Copyable).copyInto(array[index])
         } else {
-            // The array doesn't have enough elements
-            array.add(item as Copyable)
+            array[index] = (item as Copyable)
         }
     }
 
@@ -73,12 +71,12 @@ class CircularBuffer<T>(val size: Int, emptyObject: Copyable, val fullBehaviour:
         }
     }
 
-    fun add(item: T) {
+    fun add(item: T, copyInPlace: Boolean = true) {
         if(isFull()) {
             when (fullBehaviour) {
                 FULL_BEHAVIOUR.OVERWRITE -> {
                     // Add item, replace any data currently there
-                    set(head, item)
+                    set(head, item, copyInPlace)
                     // Advance front of buffer
                     incrementHead()
                     // Buffer is full, also advance tail
@@ -90,13 +88,13 @@ class CircularBuffer<T>(val size: Int, emptyObject: Copyable, val fullBehaviour:
                 }
                 FULL_BEHAVIOUR.REPLACE_LAST -> {
                     // Add item, do not advance pointers
-                    set(head, item)
+                    set(head, item, copyInPlace)
                 }
             }
 
         } else {
             // Buffer is not full, just add and advance head
-            set(head, item)
+            set(head, item, copyInPlace)
             incrementHead()
             numItems++;
         }
@@ -105,27 +103,27 @@ class CircularBuffer<T>(val size: Int, emptyObject: Copyable, val fullBehaviour:
     /**
      * Adds an item onto the tail
      */
-    fun addTail(item: T) {
+    fun addTail(item: T, copyInPlace: Boolean = true) {
         if(isFull()) {
             when (fullBehaviour) {
                 FULL_BEHAVIOUR.OVERWRITE -> {
                     // Add item to tail, drop item at head
                     decrementTail()
                     decrementHead()
-                    set(tail, item)
+                    set(tail, item, copyInPlace)
                 }
                 FULL_BEHAVIOUR.DISCARD -> {
                     // No-op, just discard item
                 }
                 FULL_BEHAVIOUR.REPLACE_LAST -> {
                     // Add item, replace current tail
-                    set(tail, item)
+                    set(tail, item, copyInPlace)
                 }
             }
         } else {
             // Decrement tail and add item
             decrementTail()
-            set(tail, item)
+            set(tail, item, copyInPlace)
             numItems++
         }
     }

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/Copyable.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/Utils/Copyable.kt
@@ -18,5 +18,6 @@ package dev.hadrosaur.videodecodeencodedemo.Utils
 
 interface Copyable {
     fun createCopy(): Copyable
+    fun copyInto(destination: Copyable)
 }
 inline fun <reified T : Copyable> T.copy(): Copyable = createCopy()


### PR DESCRIPTION
With large video files, the number of allocations and deallocations for
audio buffers can be large. Even though memory use remains reasonable
and the buffers are small, the sheer number of de/allocations can gum
things up. This reduces copies and uses circular buffers to reduce
allocations as the pipeline proceeds.