### PR TITLE
Fixed non-sequential multiple tracks

### DIFF
--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMainTrack.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMainTrack.kt
@@ -84,11 +84,8 @@ class AudioMainTrack {
         audioBuffer.add(chunkToAdd)
     }
 
-    fun addMixTrack(streamNum: Int, trackToAdd: AudioMixTrack) {
-        audioMixTracks.add(streamNum, trackToAdd)
-    }
-    fun getMixTrack(streamNum: Int): AudioMixTrack {
-        return audioMixTracks[streamNum]
+    fun addMixTrack(trackToAdd: AudioMixTrack) {
+        audioMixTracks.add(trackToAdd)
     }
 
     // Create an empty audio buffer and mix down all mix tracks into it up to bufferToPositionUs.

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMixTrackMediaClock.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/AudioHelpers/AudioMixTrackMediaClock.kt
@@ -32,7 +32,6 @@ class AudioMixTrackMediaClock (private var startTimeUs: Long = 0L) : MediaClock 
     // Set a minimum frame rate for when this clock runs as fast as possible
     private val MIN_FPS = 1L
     private val MAX_FRAME_DURATION_US =  1000000L / MIN_FPS
-//    var lastProcessedFrameUs = -1 * MAX_FRAME_DURATION_US // Initialize at -1 frame
 
     private var runAsFastAsPossible = false
     private var internalPlaybackParameters = PlaybackParameters(1.0f)
@@ -43,7 +42,6 @@ class AudioMixTrackMediaClock (private var startTimeUs: Long = 0L) : MediaClock 
     fun setPositionUs(newPosition: Long) { positionUs = newPosition }
 
     fun updateRelativePosition(newRelativeTrackPosition: Long) {
-        // logd("Updated relative position to: ${newRelativeTrackPosition}")
         positionUs = newRelativeTrackPosition - startTimeUs
     }
     fun advancePosition(advanceByUs: Long) { positionUs += advanceByUs}
@@ -54,6 +52,9 @@ class AudioMixTrackMediaClock (private var startTimeUs: Long = 0L) : MediaClock 
 
     fun reset() {
         positionUs = 0L
+    }
+
+    fun onRepeat() {
     }
 
     override fun getPositionUs(): Long {
@@ -73,11 +74,9 @@ class AudioMixTrackMediaClock (private var startTimeUs: Long = 0L) : MediaClock 
     }
 
     fun updateLastProcessedVideoPosition(videoPositionUs: Long) {
-        // logd("updateLastProcessed: ${frameProcessedUs}, current pos: ${positionUs}")
         // If a later frame has been processed, advance
         if (videoPositionUs > positionUs) {
             positionUs = videoPositionUs
-            // logd("Updated frame position to: ${frameProcessedUs}")
         }
     }
 }

--- a/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/MainActivity.kt
+++ b/app/src/main/java/dev/hadrosaur/videodecodeencodedemo/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.exoplayer2.*
+import com.google.android.exoplayer2.Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT
 import dev.hadrosaur.videodecodeencodedemo.AudioHelpers.AudioBufferManager
 import dev.hadrosaur.videodecodeencodedemo.AudioHelpers.AudioMainTrack
 import dev.hadrosaur.videodecodeencodedemo.AudioHelpers.AudioMixTrack
@@ -409,7 +410,7 @@ class MainActivity : AppCompatActivity() {
         // Set up audio track for this stream
         val startTimeUS = 0L
         val audioMixTrack = AudioMixTrack(startTimeUS)
-        audioMainTrack.addMixTrack(streamNumber, audioMixTrack)
+        audioMainTrack.addMixTrack(audioMixTrack)
 
         // Setup custom video and audio renderers
         // Here is where you could set a start time relative to master timeline
@@ -457,6 +458,12 @@ class MainActivity : AppCompatActivity() {
                     exoPlayers[streamNumber]?.release()
                     this@MainActivity.decodeFinished()
                 }
+            }
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                if (reason == MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
+                    audioMixTrack.mediaClock.onRepeat()
+                }
+                super.onMediaItemTransition(mediaItem, reason)
             }
         })
 


### PR DESCRIPTION
There was a bug if tracks 1,2, and 4 were selected due to a poor
assumption when adding audio mix tracks that stream numbers would be
sequential. Mix tracks don't need to know their index number so this
code was removed.